### PR TITLE
Removed f-strings as they are not supported on Python 3.5

### DIFF
--- a/djaa_list_filter/admin.py
+++ b/djaa_list_filter/admin.py
@@ -24,10 +24,10 @@ class AjaxAutocompleteSelectWidget(AutocompleteSelect):
 
     def render(self, name, value, attrs=None, renderer=None):
         rendered = super().render(name, value, attrs, renderer)
-        return (
-            f'<div class="ajax-autocomplete-select-widget-wrapper" data-qs-target-value="{self.qs_target_value}">'
-            f'{rendered}'
-            '</div>'
+        return ("""
+            <div class="ajax-autocomplete-select-widget-wrapper" data-qs-target-value="{qs_target_value}">
+                {rendered}
+            </div>""".format(qs_target_value=self.qs_target_value, rendered=rendered)
         )
 
 


### PR DESCRIPTION
Package does not work on Python 3.5 due to the use of `f` strings:

```
File "/usr/local/lib/python3.5/dist-packages/djaa_list_filter/admin.py", line 28
 f'<div class="ajax-autocomplete-select-widget-wrapper" data-qs-target-value="{self.qs_target_value}">'
SyntaxError: invalid syntax
```

Django (2.1, 2.2) supports Python: 3.5, 3.6, 3.7. To keep in parity with Django, I removed the use of f-strings.
