### PR TITLE
Use `static` instead of `staticfiles` in templates

### DIFF
--- a/djaa_list_filter/templates/djaa_list_filter/admin/filter/autocomplete_list_filter.html
+++ b/djaa_list_filter/templates/djaa_list_filter/admin/filter/autocomplete_list_filter.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 
 <form method="get">


### PR DESCRIPTION
I got the error during template rendering because the `staticfiles` and `admin_static` template tag libraries are removed in 3.0. These were already [deprecated in 2.1](https://docs.djangoproject.com/en/3.0/releases/2.1/#deprecated-features-2-1). I fixed this with the use of `static` instead of `staticfiles`. Would you be able to review this, please?