### PR TITLE
Unbreak "normal" autocomplete lists

### DIFF
--- a/djaa_list_filter/static/djaa_list_filter/admin/css/autocomplete_list_filter.css
+++ b/djaa_list_filter/static/djaa_list_filter/admin/css/autocomplete_list_filter.css
@@ -1,3 +1,3 @@
-.select2-container--admin-autocomplete {
+.ajax-autocomplete-select-widget-wrapper .select2-container--admin-autocomplete {
     width: 100% !important;
 }


### PR DESCRIPTION
Do not apply the `width: 100% !important` rule to select2 components on
regular admin forms.

Before:
<img width="775" alt="Screenshot 2021-09-02 at 18 27 15" src="https://user-images.githubusercontent.com/193923/131883699-bf6b4c99-4675-4f8e-80b7-f538c295cf1a.png">

After:

<img width="782" alt="Screenshot 2021-09-02 at 18 27 08" src="https://user-images.githubusercontent.com/193923/131883732-f6bbd9dc-f3fa-4fca-869e-298d3713704d.png">
