### PR TITLE
Make autocomplete filters collapsible

### DIFF
--- a/djaa_list_filter/templates/djaa_list_filter/admin/filter/autocomplete_list_filter.html
+++ b/djaa_list_filter/templates/djaa_list_filter/admin/filter/autocomplete_list_filter.html
@@ -1,9 +1,13 @@
 {% load i18n static %}
-<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
+<details data-filter-title="{{ title }}" open>
+    <summary>
+        {% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}
+    </summary>
 
-<form method="get">
-<ul>
-    <li>{{ spec.autocomplete_form.autocomplete_field }}</li>
-</ul>
-{{ spec.autocomplete_form.querystring_value }}
-</form>
+    <form method="get">
+        <ul>
+            <li>{{ spec.autocomplete_form.autocomplete_field }}</li>
+        </ul>
+        {{ spec.autocomplete_form.querystring_value }}
+    </form>
+</details>


### PR DESCRIPTION
Make autocomplete filter be collapsible and match the aesthetic of Django filters in v4. 

New look:
![image](https://user-images.githubusercontent.com/2993698/196782068-f49a2e27-6cb1-4884-b154-aba7651b031e.png)

Previous look:
![image](https://user-images.githubusercontent.com/2993698/196782213-68dbebb3-0ccd-4903-8bc7-95922753eb7d.png)
